### PR TITLE
fix: refactor OutlineClient sanitization and fix linting

### DIFF
--- a/tests/utils/test_outline_client.py
+++ b/tests/utils/test_outline_client.py
@@ -101,7 +101,7 @@ class TestOutlineClient:
             OutlineClient(api_key=None)
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("value", ['""', "''"])
+    @pytest.mark.parametrize("value", ['""', "''", "   "])
     async def test_api_key_only_quotes_triggers_missing(self, value):
         """API keys that are only quotes should be treated
         as missing and raise OutlineError."""
@@ -313,7 +313,7 @@ class TestOutlineClient:
                 with pytest.raises(OutlineError) as exc_info:
                     await client.post("test_endpoint")
 
-                # Should have attempted to sleep twice before exhausting retries
+                # Should have slept twice before exhausting retries
                 assert mock_sleep.call_count == 2
 
                 # Error message should include HTTP status


### PR DESCRIPTION
## Summary
- Extract `_sanitize_value()` helper to deduplicate quote-stripping logic
- Simplify URL normalization using `endswith('/api')` check
- Fix line-length linting violations (80 > 79)
- Add whitespace-only API key test case
- Remove redundant `rstrip()` in post method
- Remove unused `urlparse` import

## Test plan
- [x] `uv run ruff check .` passes
- [x] `uv run pyright src/` passes
- [x] `uv run pytest tests/utils/test_outline_client.py -v` passes (25 tests)