### PR TITLE
ci: add Claude Code hooks for auto-format and sensitive file protection

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,27 @@
 {
-  "includeCoAuthoredBy": false
+  "includeCoAuthoredBy": false,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "for f in $CLAUDE_FILE_PATHS; do case \"$f\" in *.env|*.env.*|uv.lock|*.lock) echo \"BLOCK: refusing to edit $f\" >&2; exit 1;; esac; done"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ruff format $CLAUDE_FILE_PATHS && uv run ruff check --fix $CLAUDE_FILE_PATHS"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Add **PreToolUse hook** that blocks edits to `.env`, `.env.*`, `uv.lock`, and `*.lock` files
- Add **PostToolUse hook** that auto-runs `ruff format` + `ruff check --fix` after every Edit/Write