### PR TITLE
feat: add list_recently_updated_documents tool

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "mcp-outline",
       "source": "./",
       "description": "Connect Claude Code to Outline for document search, reading, creation, and management",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "author": {
         "name": "Vortiago"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-outline",
   "description": "Connect Claude Code to Outline for document search, reading, creation, and management",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": {
     "name": "Vortiago"
   },

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "mcp-outline": {
       "command": "uvx",
-      "args": ["mcp-outline==1.9.0"],
+      "args": ["mcp-outline==1.10.0"],
       "env": {
         "OUTLINE_API_KEY": "${OUTLINE_API_KEY:-}",
         "OUTLINE_API_URL": "${OUTLINE_API_URL:-}",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ This MCP server bridges AI assistants with Outline's document management platfor
 register_all(mcp)
   |- health.register_routes(mcp)               # Always
   |- documents.register(mcp)
-  |   |- document_search.register_tools()      # Always
+  |   |- document_search.register_tools()      # Always (recent-changes tool: if not OUTLINE_DISABLE_RECENT_DOCUMENTS)
   |   |- document_reading.register_tools()     # Always
   |   |- document_navigation.register_tools()  # Always
   |   |- document_attachments.register_tools() # Always
@@ -365,6 +365,7 @@ OUTLINE_CACHE_MAX_SIZE=100                 # Max cached documents (default: 100)
 OUTLINE_DISABLE_AI_TOOLS=true              # Disable AI tools
 OUTLINE_READ_ONLY=true                     # Disable all write operations
 OUTLINE_DISABLE_DELETE=true                # Disable delete operations only
+OUTLINE_DISABLE_RECENT_DOCUMENTS=true      # Disable the recent-changes tool only
 OUTLINE_DYNAMIC_TOOL_LIST=true             # Enable per-user tool filtering (requires apiKeys.list scope)
 
 # MCP server (optional)
@@ -376,6 +377,7 @@ MCP_PORT=3000                              # Server port
 **Access Control Notes**:
 - `OUTLINE_READ_ONLY`: Blocks entire write modules at registration (content, lifecycle, organization, batch_operations)
 - `OUTLINE_DISABLE_DELETE`: Conditionally registers delete tools within document_lifecycle and collection_tools
+- `OUTLINE_DISABLE_RECENT_DOCUMENTS`: Conditionally registers the `list_recently_updated_documents` tool within document_search (opt-out; registered by default)
 - `OUTLINE_DYNAMIC_TOOL_LIST`: Off by default. Uses `apiKeys.list` to introspect API key scopes and filters tools per-user based on scope matching. Scoped API keys must include `apiKeys.list` in their scope array for introspection to work. Fail-open: if scope introspection fails, all tools are shown. Set to `true` to enable.
 - Read-only mode takes precedence: If both are set, server operates in read-only mode
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Setup guides for more clients: [Docker (HTTP), Cline, Codex, Windsurf, and other
 | `OUTLINE_READ_ONLY` | No | `false` | `true` = disable ALL write operations ([details](docs/configuration.md#read-only-mode)) |
 | `OUTLINE_DISABLE_DELETE` | No | `false` | `true` = disable only delete operations ([details](docs/configuration.md#disable-delete-operations)) |
 | `OUTLINE_DISABLE_AI_TOOLS` | No | `false` | `true` = disable AI tools (for Outline instances without OpenAI) |
+| `OUTLINE_DISABLE_RECENT_DOCUMENTS` | No | `false` | `true` = disable the `list_recently_updated_documents` tool |
 | `OUTLINE_DYNAMIC_TOOL_LIST` | No | `false` | `true` = enable per-user tool filtering by role/key scopes ([details](docs/configuration.md#dynamic-tool-list)) |
 | `OUTLINE_MAX_CONNECTIONS` | No | `100` | Max concurrent connections in pool |
 | `OUTLINE_MAX_KEEPALIVE` | No | `20` | Max idle connections in pool |
@@ -155,6 +156,7 @@ Setup guides for more clients: [Docker (HTTP), Cline, Codex, Windsurf, and other
 |---------|---------|--------|
 | Read-only mode | `OUTLINE_READ_ONLY=true` | Disables all write operations — only search, read, and export tools available |
 | Disable deletes | `OUTLINE_DISABLE_DELETE=true` | Disables only delete operations, all other writes allowed |
+| Disable recent-changes tool | `OUTLINE_DISABLE_RECENT_DOCUMENTS=true` | Disables only the `list_recently_updated_documents` tool |
 | Dynamic tool list | `OUTLINE_DYNAMIC_TOOL_LIST=true` | Filters tools per-user based on Outline role and API key scopes |
 | Per-user Outline API keys | `x-outline-api-key` header | Each user passes their own Outline API key in HTTP mode for multi-user setups |
 
@@ -166,6 +168,7 @@ Read-only mode takes precedence over disable-delete. See [Configuration Guide](d
 
 ### Search & Discovery
 - `search_documents(query, collection_id?, limit?, offset?, statusFilter?)` - Search documents by keywords with pagination. Defaults to published documents; pass `statusFilter` with `draft`, `archived`, and/or `published` to include other states
+- `list_recently_updated_documents(date_filter?, collection_id?, status_filter?, limit?, offset?)` - List documents by most recent change, newest first (e.g. "what changed this week"). `date_filter` windows by last change: `day`/`week`/`month`/`year` (default `week`). Defaults to published documents
 - `list_collections()` - List all collections
 - `get_collection_structure(collection_id)` - Get document hierarchy within a collection
 - `get_document_id_from_title(query, collection_id?)` - Find document ID by title search

--- a/agents/outline-explorer.md
+++ b/agents/outline-explorer.md
@@ -78,6 +78,7 @@ Exploration process:
 
 Available tools (identified by suffix — use whatever full name appears in your tool list):
 - `search_documents` — search for documents by keywords
+- `list_recently_updated_documents` — list documents by most recent change (e.g. "what changed this week"); optional `date_filter` time window
 - `read_document` — read document content (supports offset/limit for line ranges)
 - `get_document_toc` — get heading structure with line numbers (use before reading sections)
 - `read_document_section` — read a specific section by heading name (preferred over full read)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,17 @@ Set `OUTLINE_DISABLE_DELETE=true` to allow create and update workflows while pre
 
 **Important:** `OUTLINE_READ_ONLY=true` takes precedence over `OUTLINE_DISABLE_DELETE`. If both are set, the server operates in read-only mode.
 
+## Disable Recent-Changes Tool
+
+Set `OUTLINE_DISABLE_RECENT_DOCUMENTS=true` to hide the `list_recently_updated_documents` tool. Only this tool is disabled.
+
+**Use cases:**
+- Trimming the tool list when a recent-changes view isn't needed
+- Deployments that prefer `search_documents` as the only discovery path
+
+**Disabled tools:**
+- `list_recently_updated_documents`
+
 ## Multi-User Setup (HTTP)
 
 When running in HTTP mode (`sse` or `streamable-http`), multiple users can share a single MCP server, each authenticating with their own Outline API key.

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Vortiago/mcp-outline",
   "title": "Outline MCP Server",
   "description": "Connect AI assistants to Outline for document search, reading, and management",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "websiteUrl": "https://github.com/Vortiago/mcp-outline",
   "repository": {
     "url": "https://github.com/Vortiago/mcp-outline",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "mcp-outline",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/skills/outline/SKILL.md
+++ b/skills/outline/SKILL.md
@@ -28,8 +28,9 @@ description: Conventions and efficient workflows for Outline knowledge bases via
 
 ## Search defaults to published only
 
-Drafts and archived docs are invisible to `search_documents` unless
-widened: `status_filter=["draft", "published", "archived"]`.
+Drafts and archived docs are invisible to `search_documents` and
+`list_recently_updated_documents` unless widened:
+`status_filter=["draft", "published", "archived"]`.
 
 ## Reading large documents
 

--- a/src/mcp_outline/features/documents/document_search.py
+++ b/src/mcp_outline/features/documents/document_search.py
@@ -4,6 +4,7 @@ Document search tools for the MCP Outline server.
 This module provides MCP tools for searching and listing documents.
 """
 
+import os
 from typing import Any, Dict, List, Literal, Optional
 
 from mcp.types import ToolAnnotations
@@ -138,6 +139,9 @@ def register_tools(mcp) -> None:
     Args:
         mcp: The FastMCP server instance
     """
+    disable_recent = os.getenv(
+        "OUTLINE_DISABLE_RECENT_DOCUMENTS", ""
+    ).lower() in ("true", "1", "yes")
 
     @mcp.tool(
         annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
@@ -356,3 +360,86 @@ def register_tools(mcp) -> None:
             return f"Error searching for document: {str(e)}"
         except Exception as e:
             return f"Unexpected error: {str(e)}"
+
+    if not disable_recent:
+
+        @mcp.tool(
+            annotations=ToolAnnotations(
+                readOnlyHint=True, idempotentHint=True
+            ),
+            meta={
+                "endpoint": "documents.search",
+                "min_role": "viewer",
+            },
+        )
+        async def list_recently_updated_documents(
+            date_filter: Optional[
+                Literal["day", "week", "month", "year"]
+            ] = "week",
+            collection_id: Optional[str] = None,
+            status_filter: Optional[
+                List[Literal["draft", "archived", "published"]]
+            ] = None,
+            limit: int = 25,
+            offset: int = 0,
+        ) -> str:
+            """
+            Lists documents ordered by most recent change (newest first).
+
+            Answers questions like "what changed this week" without needing
+            search keywords. Backed by Outline's search endpoint with an empty
+            query, sorted by last-modified time.
+
+            IMPORTANT: date_filter is a coarse server-side window on each
+            document's last-modified time. It accepts only "day", "week",
+            "month", or "year" (no arbitrary timestamps) and defaults to
+            "week". Results are ordered newest-changed first.
+
+            STATUS FILTER: By default this lists published documents only.
+            Pass status_filter to include other states. Allowed values are
+            "draft", "archived", and "published". Drafts only ever include
+            those you are allowed to see.
+
+            PAGINATION: Returns up to limit documents (default 25). Use offset
+            to page through older changes.
+
+            Use this tool when you need to:
+            - Answer "what documents changed recently / this week"
+            - Review recent activity, optionally within one collection
+            - Catch up on edits since you last looked
+
+            Args:
+                date_filter: Time window on last-modified time. One of "day",
+                    "week", "month", "year". Defaults to "week".
+                collection_id: Optional collection to limit results to
+                status_filter: Optional list of statuses to include. Allowed
+                    values are "draft", "archived", and "published". Defaults
+                    to published only.
+                limit: Maximum number of documents to return (default: 25)
+                offset: Number of documents to skip for pagination (default: 0)
+
+            Returns:
+                Formatted string listing documents with their IDs and
+                last-updated timestamps, newest first
+            """
+            try:
+                client = await get_outline_client()
+                response = await client.search_documents(
+                    query="",
+                    collection_id=collection_id,
+                    limit=limit,
+                    offset=offset,
+                    status_filter=status_filter,
+                    sort="updatedAt",
+                    direction="DESC",
+                    date_filter=date_filter,
+                )
+                results = response.get("data", [])
+                documents = [result.get("document", {}) for result in results]
+                return _format_documents_list(
+                    documents, "Recently Updated Documents"
+                )
+            except OutlineClientError as e:
+                return f"Error listing recently updated documents: {str(e)}"
+            except Exception as e:
+                return f"Unexpected error: {str(e)}"

--- a/src/mcp_outline/server.py
+++ b/src/mcp_outline/server.py
@@ -50,19 +50,29 @@ port = int(os.getenv("MCP_PORT", "3000"))
 
 # Server instructions — injected into the LLM's system prompt
 # by MCP clients. Keep under 2KB (Claude Code truncates at 2KB).
-def _build_instructions(read_only: bool) -> str:
+def _build_instructions(read_only: bool, recent_documents: bool = True) -> str:
     """Build MCP instructions matching the registered tools.
 
-    Editing guidance is omitted in read-only mode so the
-    LLM is never directed to unregistered tools.
+    Guidance is omitted for tools that are not registered so the
+    LLM is never directed to them: editing guidance in read-only
+    mode, and the recent-changes tool when
+    OUTLINE_DISABLE_RECENT_DOCUMENTS is set.
     """
+    finding = (
+        "Finding content: search_documents or "
+        "get_document_id_from_title to get document IDs, "
+        "list_collections to discover collections"
+    )
+    if recent_documents:
+        finding += (
+            ", list_recently_updated_documents to see what changed recently"
+        )
+    finding += "."
     parts = [
         "Manages documents in Outline, a wiki and knowledge "
         "base. Use for searching, reading, navigating, "
         "editing, and organizing documents and collections.",
-        "Finding content: search_documents or "
-        "get_document_id_from_title to get document IDs, "
-        "list_collections to discover collections.",
+        finding,
         "Large documents: start with get_document_toc to "
         "see heading structure, then read_document_section "
         "to read by heading, search_document_content to "
@@ -90,7 +100,9 @@ def _build_instructions(read_only: bool) -> str:
 
 _INSTRUCTIONS = _build_instructions(
     read_only=os.getenv("OUTLINE_READ_ONLY", "").lower()
-    in ("true", "1", "yes")
+    in ("true", "1", "yes"),
+    recent_documents=os.getenv("OUTLINE_DISABLE_RECENT_DOCUMENTS", "").lower()
+    not in ("true", "1", "yes"),
 )
 
 # Create a FastMCP server instance with a name and port configuration

--- a/src/mcp_outline/utils/outline_client.py
+++ b/src/mcp_outline/utils/outline_client.py
@@ -367,25 +367,37 @@ class OutlineClient:
 
     async def search_documents(
         self,
-        query: str,
+        query: str = "",
         collection_id: Optional[str] = None,
         limit: int = 25,
         offset: int = 0,
         status_filter: Optional[
             List[Literal["draft", "archived", "published"]]
         ] = None,
+        sort: Optional[str] = None,
+        direction: Optional[str] = None,
+        date_filter: Optional[Literal["day", "week", "month", "year"]] = None,
     ) -> Dict[str, Any]:
         """
         Search for documents using keywords.
 
+        An empty ``query`` turns this into a plain listing ordered by ``sort``
+        (the Outline ``documents.search`` endpoint allows an empty query),
+        which is how recency listings are built.
+
         Args:
-            query: Search terms
+            query: Search terms. Empty string lists without ranking.
             collection_id: Optional collection to search within
             limit: Maximum number of results to return (default: 25)
             offset: Number of results to skip for pagination (default: 0)
             status_filter: Document statuses to include in results. Allowed
                 values are "draft", "archived", and "published". Defaults to
                 ["published"].
+            sort: Optional field to order by (e.g. "updatedAt", "createdAt",
+                "title").
+            direction: Optional sort direction ("ASC" or "DESC").
+            date_filter: Optional server-side window on last-modified time.
+                One of "day", "week", "month", or "year".
 
         Returns:
             Dict containing 'data' (list of results) and 'pagination' metadata
@@ -400,6 +412,12 @@ class OutlineClient:
         }
         if collection_id:
             data["collectionId"] = collection_id
+        if sort:
+            data["sort"] = sort
+        if direction:
+            data["direction"] = direction
+        if date_filter:
+            data["dateFilter"] = date_filter
 
         response = await self.post("documents.search", data)
         return response

--- a/tests/e2e/test_dynamic_tool_list.py
+++ b/tests/e2e/test_dynamic_tool_list.py
@@ -283,6 +283,7 @@ async def test_route_scoped_read_only(
         "search_document_content",
         "export_document",
         "search_documents",
+        "list_recently_updated_documents",
         "get_document_id_from_title",
         "list_collections",
         "get_collection_structure",
@@ -341,6 +342,7 @@ async def test_namespace_read_scope(
         "search_document_content",  # documents.info
         "export_document",  # documents.export
         "search_documents",  # documents.search
+        "list_recently_updated_documents",  # documents.search
         "get_document_id_from_title",  # documents.search
         "get_document_backlinks",  # documents.list
         "list_document_attachments",  # documents.info
@@ -383,6 +385,7 @@ async def test_namespace_write_documents_only(
         "search_document_content",
         "export_document",
         "search_documents",
+        "list_recently_updated_documents",
         "get_document_id_from_title",
         "get_document_backlinks",
         "list_document_attachments",
@@ -442,6 +445,7 @@ async def test_mixed_namespace_and_route_scope(
         "search_document_content",
         "export_document",
         "search_documents",
+        "list_recently_updated_documents",
         "get_document_id_from_title",
         "get_document_backlinks",
         "list_document_attachments",

--- a/tests/e2e/test_search.py
+++ b/tests/e2e/test_search.py
@@ -158,3 +158,37 @@ async def test_search_documents(mcp_session):
             pytest.fail("Document not found in search")
 
         assert "# Search Results" in text
+
+
+async def test_list_recently_updated_documents(mcp_session):
+    """A freshly created document appears in the recent-changes listing.
+
+    Uses a retry loop because Outline's search index (which backs the
+    empty-query + dateFilter listing) is updated asynchronously.
+    Guards against: list_recently_updated_documents ignoring the time
+    window, failing on an empty query, or omitting recently changed docs.
+    """
+    async with mcp_session() as session:
+        coll_id = await _create_collection(session, "E2E Recent Changes")
+
+        unique = f"recent{uuid.uuid4().hex[:8]}"
+        await _create_document(
+            session,
+            coll_id,
+            f"Recently {unique}",
+            "Fresh content.",
+        )
+
+        for _ in range(10):
+            result = await session.call_tool(
+                "list_recently_updated_documents",
+                arguments={"date_filter": "week"},
+            )
+            text = _text(result)
+            if unique in text:
+                break
+            await anyio.sleep(2)
+        else:
+            pytest.fail("New document not found in recent changes")
+
+        assert "# Recently Updated Documents" in text

--- a/tests/features/documents/test_document_search.py
+++ b/tests/features/documents/test_document_search.py
@@ -258,6 +258,131 @@ class TestDocumentSearchTools:
 
     @pytest.mark.asyncio
     @patch("mcp_outline.features.documents.document_search.get_outline_client")
+    async def test_list_recently_updated_documents_success(
+        self, mock_get_client, register_search_tools
+    ):
+        """Tool returns recent docs with titles, IDs, and timestamps."""
+        mock_client = AsyncMock()
+        mock_client.search_documents.return_value = {
+            "data": [
+                {
+                    "document": {
+                        "id": "doc1",
+                        "title": "Test Document 1",
+                        "updatedAt": "2026-06-20T12:00:00Z",
+                    }
+                }
+            ],
+            "pagination": {"limit": 25, "offset": 0},
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await register_search_tools.tools[
+            "list_recently_updated_documents"
+        ]()
+
+        assert "Test Document 1" in result
+        assert "doc1" in result
+        assert "2026-06-20T12:00:00Z" in result
+
+    @pytest.mark.asyncio
+    @patch("mcp_outline.features.documents.document_search.get_outline_client")
+    async def test_list_recently_updated_documents_defaults(
+        self, mock_get_client, register_search_tools
+    ):
+        """Defaults to an empty query, week window, updatedAt DESC."""
+        mock_client = AsyncMock()
+        mock_client.search_documents.return_value = {
+            "data": [],
+            "pagination": {},
+        }
+        mock_get_client.return_value = mock_client
+
+        await register_search_tools.tools["list_recently_updated_documents"]()
+
+        mock_client.search_documents.assert_called_once_with(
+            query="",
+            collection_id=None,
+            limit=25,
+            offset=0,
+            status_filter=None,
+            sort="updatedAt",
+            direction="DESC",
+            date_filter="week",
+        )
+
+    @pytest.mark.asyncio
+    @patch("mcp_outline.features.documents.document_search.get_outline_client")
+    async def test_list_recently_updated_documents_forwards_params(
+        self, mock_get_client, register_search_tools
+    ):
+        """date_filter, collection_id, status_filter, paging are forwarded."""
+        mock_client = AsyncMock()
+        mock_client.search_documents.return_value = {
+            "data": [],
+            "pagination": {},
+        }
+        mock_get_client.return_value = mock_client
+
+        await register_search_tools.tools["list_recently_updated_documents"](
+            date_filter="day",
+            collection_id="coll1",
+            status_filter=["published", "draft"],
+            limit=50,
+            offset=10,
+        )
+
+        mock_client.search_documents.assert_called_once_with(
+            query="",
+            collection_id="coll1",
+            limit=50,
+            offset=10,
+            status_filter=["published", "draft"],
+            sort="updatedAt",
+            direction="DESC",
+            date_filter="day",
+        )
+
+    @pytest.mark.asyncio
+    @patch("mcp_outline.features.documents.document_search.get_outline_client")
+    async def test_list_recently_updated_documents_empty(
+        self, mock_get_client, register_search_tools
+    ):
+        """No recent changes yields a friendly empty message."""
+        mock_client = AsyncMock()
+        mock_client.search_documents.return_value = {
+            "data": [],
+            "pagination": {},
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await register_search_tools.tools[
+            "list_recently_updated_documents"
+        ]()
+
+        assert "No recently updated documents" in result
+
+    @pytest.mark.asyncio
+    @patch("mcp_outline.features.documents.document_search.get_outline_client")
+    async def test_list_recently_updated_documents_client_error(
+        self, mock_get_client, register_search_tools
+    ):
+        """Client errors are caught and returned as a string."""
+        mock_client = AsyncMock()
+        mock_client.search_documents.side_effect = OutlineClientError(
+            "API error"
+        )
+        mock_get_client.return_value = mock_client
+
+        result = await register_search_tools.tools[
+            "list_recently_updated_documents"
+        ]()
+
+        assert "Error" in result
+        assert "API error" in result
+
+    @pytest.mark.asyncio
+    @patch("mcp_outline.features.documents.document_search.get_outline_client")
     async def test_list_collections_success(
         self, mock_get_client, register_search_tools
     ):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -53,6 +53,24 @@ def test_instructions_omit_editing_in_read_only_mode():
     assert "get_document_toc" in text
 
 
+def test_instructions_mention_recent_documents_by_default():
+    """Default instructions point the LLM at the recent-changes tool."""
+    from mcp_outline.server import _build_instructions
+
+    text = _build_instructions(read_only=False)
+    assert "list_recently_updated_documents" in text
+
+
+def test_instructions_omit_recent_documents_when_disabled():
+    """Disabling the recent-changes tool drops it from the guidance."""
+    from mcp_outline.server import _build_instructions
+
+    text = _build_instructions(read_only=False, recent_documents=False)
+    assert "list_recently_updated_documents" not in text
+    # Other finding-content tools are still advertised
+    assert "search_documents" in text
+
+
 @pytest.mark.anyio
 async def test_ai_tools_disabled_via_env_var(fresh_mcp_server):
     """Test that AI tools are not registered when disabled via env var."""
@@ -139,6 +157,36 @@ async def test_disable_delete_blocks_deletes_only(fresh_mcp_server):
         assert "archive_document" in tool_names
         assert "create_collection" in tool_names
         assert "update_collection" in tool_names
+
+
+@pytest.mark.anyio
+async def test_disable_recent_documents_blocks_only_that_tool(
+    fresh_mcp_server,
+):
+    """OUTLINE_DISABLE_RECENT_DOCUMENTS hides only the recent-changes tool."""
+    with patch.dict(os.environ, {"OUTLINE_DISABLE_RECENT_DOCUMENTS": "true"}):
+        register_all(fresh_mcp_server)
+        tools = await fresh_mcp_server.list_tools()
+        tool_names = [tool.name for tool in tools]
+
+        # The recent-changes tool is NOT registered
+        assert "list_recently_updated_documents" not in tool_names
+
+        # Other read tools in the same module ARE still registered
+        assert "search_documents" in tool_names
+        assert "list_collections" in tool_names
+
+
+@pytest.mark.anyio
+async def test_recent_documents_tool_registered_by_default(fresh_mcp_server):
+    """The recent-changes tool is registered when the flag is unset."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("OUTLINE_DISABLE_RECENT_DOCUMENTS", None)
+        register_all(fresh_mcp_server)
+        tools = await fresh_mcp_server.list_tools()
+        tool_names = [tool.name for tool in tools]
+
+        assert "list_recently_updated_documents" in tool_names
 
 
 @pytest.mark.anyio

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -26,6 +26,7 @@ async def test_read_only_tools_have_correct_annotations(fresh_mcp_server):
     # Define expected read-only tools
     read_only_tools = [
         "search_documents",
+        "list_recently_updated_documents",
         "read_document",
         "get_attachment_url",
         "fetch_attachment",
@@ -129,6 +130,7 @@ async def test_idempotent_tools(fresh_mcp_server):
         "delete_document",
         "archive_document",
         "search_documents",
+        "list_recently_updated_documents",
         "batch_delete_documents",
         "read_document",
         "get_attachment_url",

--- a/tests/utils/test_outline_client.py
+++ b/tests/utils/test_outline_client.py
@@ -524,6 +524,55 @@ class TestOutlineClient:
         )
 
     @pytest.mark.asyncio
+    async def test_search_documents_forwards_recency_params(self):
+        """documents.search forwards sort/direction/dateFilter and allows an
+        empty query so it can act as a recency listing."""
+        client = OutlineClient()
+
+        with patch.object(
+            client,
+            "post",
+            new=AsyncMock(return_value={"data": [], "pagination": {}}),
+        ) as mock_post:
+            result = await client.search_documents(
+                query="",
+                sort="updatedAt",
+                direction="DESC",
+                date_filter="week",
+            )
+
+        mock_post.assert_called_once_with(
+            "documents.search",
+            {
+                "query": "",
+                "limit": 25,
+                "offset": 0,
+                "statusFilter": ["published"],
+                "sort": "updatedAt",
+                "direction": "DESC",
+                "dateFilter": "week",
+            },
+        )
+        assert result == {"data": [], "pagination": {}}
+
+    @pytest.mark.asyncio
+    async def test_search_documents_omits_recency_params_by_default(self):
+        """sort/direction/dateFilter keys are absent when not provided."""
+        client = OutlineClient()
+
+        with patch.object(
+            client,
+            "post",
+            new=AsyncMock(return_value={"data": []}),
+        ) as mock_post:
+            await client.search_documents("policy")
+
+        sent = mock_post.call_args.args[1]
+        assert "sort" not in sent
+        assert "direction" not in sent
+        assert "dateFilter" not in sent
+
+    @pytest.mark.asyncio
     async def test_get_attachment_redirect_url_success(self):
         """Test get_attachment_redirect_url returns Location header."""
         client = OutlineClient()


### PR DESCRIPTION
Closes #119

## What
Adds a read-only MCP tool **`list_recently_updated_documents`** so an AI agent can answer "what docs changed this week" without keyword guessing.

## Approach
Backed by Outline's `documents.search` endpoint called with an **empty query + `dateFilter`** — the only documents endpoint with a server-side last-modified window (the Postgres provider applies `updatedAt > now() - interval '1 <bucket>'`, and an empty `query` turns search into a plain recency listing). Verified against the `outline/outline` source. Read-only, **viewer** role, `documents:read` scope.

`documents.list` was rejected (no server-side date filter); `events.list` was rejected (admin-gated, returns events not documents).

## Interface
- **`list_recently_updated_documents(date_filter?, collection_id?, status_filter?, limit?, offset?)`** — `date_filter` ∈ `day|week|month|year` (default `week`), published-only by default. Output shows each doc's `Last Updated:` timestamp (reuses `_format_documents_list`).
- Extended `OutlineClient.search_documents` with `sort` / `direction` / `date_filter` (and `query` now defaults to `""`); new keys are only sent when set, so existing callers are unaffected.
- **Gated** by an opt-out flag **`OUTLINE_DISABLE_RECENT_DOCUMENTS`** (registered by default), matching the `OUTLINE_DISABLE_DELETE` pattern. Server instructions omit the tool when it is disabled.

## Docs
README (flags + access-control tables + tool list), `docs/configuration.md`, `CLAUDE.md`, `agents/outline-explorer.md`, `skills/outline/SKILL.md`.

## Tests
- Unit: client param forwarding, tool happy-path/defaults/forwarding/empty/error, env-flag gating (`test_server.py`), tool-annotation lists, and adaptive server instructions.
- E2E: a new slice in `tests/e2e/test_search.py`, plus updated exact per-scope tool sets in `tests/e2e/test_dynamic_tool_list.py`.
- Verified locally: **540 unit + 16 integration pass**, full **e2e suite passes against a real Outline stack**, `ruff format`/`ruff check`/`pyright` clean.

Per Conventional Commits this is a `feat:` → **minor** version bump at release time (no version bump included here).