### PR TITLE
refactor: collapse duplicated request and batch skeletons into deep cores

### DIFF
--- a/src/mcp_outline/features/documents/batch_operations.py
+++ b/src/mcp_outline/features/documents/batch_operations.py
@@ -293,14 +293,17 @@ def register_tools(mcp) -> None:
                 "parent_document_id."
             )
 
-        async def op(client: OutlineClient, doc_id: str) -> Dict[str, Any]:
-            data = {"id": doc_id}
-            if collection_id:
-                data["collectionId"] = collection_id
-            if parent_document_id:
-                data["parentDocumentId"] = parent_document_id
+        # Destination is the same for every document; build it once.
+        destination: Dict[str, str] = {}
+        if collection_id:
+            destination["collectionId"] = collection_id
+        if parent_document_id:
+            destination["parentDocumentId"] = parent_document_id
 
-            response = await client.post("documents.move", data)
+        async def op(client: OutlineClient, doc_id: str) -> Dict[str, Any]:
+            response = await client.post(
+                "documents.move", {"id": doc_id, **destination}
+            )
             if response.get("data"):
                 doc_data = response.get("data", {})
                 return _create_result_entry(

--- a/src/mcp_outline/features/documents/batch_operations.py
+++ b/src/mcp_outline/features/documents/batch_operations.py
@@ -5,7 +5,7 @@ This module provides MCP tools for performing operations on multiple
 documents efficiently.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, TypeVar
 
 from mcp.types import ToolAnnotations
 
@@ -19,6 +19,7 @@ from mcp_outline.features.documents.models import (
     BatchUpdateItem,
 )
 from mcp_outline.utils.document_cache import get_document_cache
+from mcp_outline.utils.outline_client import OutlineClient
 
 
 def _create_result_entry(
@@ -116,6 +117,70 @@ def _format_batch_results(
     return "\n".join(lines)
 
 
+T = TypeVar("T")
+
+
+async def _run_batch(
+    items: List[T],
+    operation_label: str,
+    op: Callable[[OutlineClient, T], Awaitable[Dict[str, Any]]],
+    *,
+    id_of: Callable[[T], str] = str,
+) -> str:
+    """
+    Run ``op`` over ``items`` with per-item error isolation.
+
+    Owns client acquisition, iteration, per-item error isolation,
+    success/failure tallying, and result formatting. Each ``op``
+    returns a result entry (success or expected failure); a raised
+    exception is converted into a failure entry keyed by ``id_of``.
+
+    Args:
+        items: Items to process (document IDs or spec objects).
+        operation_label: Verb shown in the summary (e.g. ``archive``).
+        op: Async per-item operation returning a result entry from
+            ``_create_result_entry``.
+        id_of: Maps an item to the id used when ``op`` raises before a
+            result entry exists. Defaults to ``str`` (the item is its
+            own id); batch create passes a constant because the id is
+            only known after a successful call.
+
+    Returns:
+        Formatted batch operation summary.
+    """
+    results: List[Dict[str, Any]] = []
+
+    try:
+        client = await get_outline_client()
+
+        for item in items:
+            try:
+                results.append(await op(client, item))
+            except OutlineClientError as e:
+                results.append(
+                    _create_result_entry(id_of(item), "failed", error=str(e))
+                )
+            except Exception as e:
+                results.append(
+                    _create_result_entry(
+                        id_of(item),
+                        "failed",
+                        error=f"Unexpected error: {str(e)}",
+                    )
+                )
+
+        succeeded = sum(1 for r in results if r["status"] == "success")
+        failed = len(results) - succeeded
+        return _format_batch_results(
+            operation_label, len(items), succeeded, failed, results
+        )
+
+    except OutlineClientError as e:
+        return f"Error initializing client: {str(e)}"
+    except Exception as e:
+        return f"Unexpected error: {str(e)}"
+
+
 def register_tools(mcp) -> None:
     """
     Register batch operation tools with the MCP server.
@@ -163,59 +228,19 @@ def register_tools(mcp) -> None:
         if not document_ids:
             return "Error: No document IDs provided."
 
-        results: List[Dict[str, Any]] = []
-        succeeded = 0
-        failed = 0
-
-        try:
-            client = await get_outline_client()
-
-            for doc_id in document_ids:
-                try:
-                    document = await client.archive_document(doc_id)
-
-                    if document:
-                        results.append(
-                            _create_result_entry(
-                                doc_id,
-                                "success",
-                                title=document.get("title", "Untitled"),
-                            )
-                        )
-                        succeeded += 1
-                    else:
-                        results.append(
-                            _create_result_entry(
-                                doc_id,
-                                "failed",
-                                error="No document returned from API",
-                            )
-                        )
-                        failed += 1
-
-                except OutlineClientError as e:
-                    results.append(
-                        _create_result_entry(doc_id, "failed", error=str(e))
-                    )
-                    failed += 1
-                except Exception as e:
-                    results.append(
-                        _create_result_entry(
-                            doc_id,
-                            "failed",
-                            error=f"Unexpected error: {str(e)}",
-                        )
-                    )
-                    failed += 1
-
-            return _format_batch_results(
-                "archive", len(document_ids), succeeded, failed, results
+        async def op(client: OutlineClient, doc_id: str) -> Dict[str, Any]:
+            document = await client.archive_document(doc_id)
+            if document:
+                return _create_result_entry(
+                    doc_id,
+                    "success",
+                    title=document.get("title", "Untitled"),
+                )
+            return _create_result_entry(
+                doc_id, "failed", error="No document returned from API"
             )
 
-        except OutlineClientError as e:
-            return f"Error initializing client: {str(e)}"
-        except Exception as e:
-            return f"Unexpected error: {str(e)}"
+        return await _run_batch(document_ids, "archive", op)
 
     @mcp.tool(
         annotations=ToolAnnotations(
@@ -268,70 +293,26 @@ def register_tools(mcp) -> None:
                 "parent_document_id."
             )
 
-        results: List[Dict[str, Any]] = []
-        succeeded = 0
-        failed = 0
+        async def op(client: OutlineClient, doc_id: str) -> Dict[str, Any]:
+            data = {"id": doc_id}
+            if collection_id:
+                data["collectionId"] = collection_id
+            if parent_document_id:
+                data["parentDocumentId"] = parent_document_id
 
-        try:
-            client = await get_outline_client()
-
-            for doc_id in document_ids:
-                try:
-                    # Build request data
-                    data = {"id": doc_id}
-
-                    if collection_id:
-                        data["collectionId"] = collection_id
-
-                    if parent_document_id:
-                        data["parentDocumentId"] = parent_document_id
-
-                    response = await client.post("documents.move", data)
-
-                    if response.get("data"):
-                        # Get document title for success message
-                        doc_data = response.get("data", {})
-                        results.append(
-                            _create_result_entry(
-                                doc_id,
-                                "success",
-                                title=doc_data.get("title", "Untitled"),
-                            )
-                        )
-                        succeeded += 1
-                    else:
-                        results.append(
-                            _create_result_entry(
-                                doc_id,
-                                "failed",
-                                error="Failed to move document",
-                            )
-                        )
-                        failed += 1
-
-                except OutlineClientError as e:
-                    results.append(
-                        _create_result_entry(doc_id, "failed", error=str(e))
-                    )
-                    failed += 1
-                except Exception as e:
-                    results.append(
-                        _create_result_entry(
-                            doc_id,
-                            "failed",
-                            error=f"Unexpected error: {str(e)}",
-                        )
-                    )
-                    failed += 1
-
-            return _format_batch_results(
-                "move", len(document_ids), succeeded, failed, results
+            response = await client.post("documents.move", data)
+            if response.get("data"):
+                doc_data = response.get("data", {})
+                return _create_result_entry(
+                    doc_id,
+                    "success",
+                    title=doc_data.get("title", "Untitled"),
+                )
+            return _create_result_entry(
+                doc_id, "failed", error="Failed to move document"
             )
 
-        except OutlineClientError as e:
-            return f"Error initializing client: {str(e)}"
-        except Exception as e:
-            return f"Unexpected error: {str(e)}"
+        return await _run_batch(document_ids, "move", op)
 
     @mcp.tool(
         annotations=ToolAnnotations(
@@ -374,88 +355,31 @@ def register_tools(mcp) -> None:
         if not document_ids:
             return "Error: No document IDs provided."
 
-        results: List[Dict[str, Any]] = []
-        succeeded = 0
-        failed = 0
-
-        try:
-            client = await get_outline_client()
-
-            for doc_id in document_ids:
-                try:
-                    if permanent:
-                        success = await client.permanently_delete_document(
-                            doc_id
-                        )
-                        if success:
-                            results.append(
-                                _create_result_entry(
-                                    doc_id,
-                                    "success",
-                                    title="Permanently deleted",
-                                )
-                            )
-                            succeeded += 1
-                        else:
-                            results.append(
-                                _create_result_entry(
-                                    doc_id,
-                                    "failed",
-                                    error="Permanent deletion failed",
-                                )
-                            )
-                            failed += 1
-                    else:
-                        # Get document details before deleting
-                        document = await client.get_document(doc_id)
-                        doc_title = document.get("title", "Untitled")
-
-                        # Move to trash
-                        response = await client.post(
-                            "documents.delete", {"id": doc_id}
-                        )
-
-                        if response.get("success", False):
-                            results.append(
-                                _create_result_entry(
-                                    doc_id, "success", title=doc_title
-                                )
-                            )
-                            succeeded += 1
-                        else:
-                            results.append(
-                                _create_result_entry(
-                                    doc_id,
-                                    "failed",
-                                    error="Failed to move to trash",
-                                )
-                            )
-                            failed += 1
-
-                except OutlineClientError as e:
-                    results.append(
-                        _create_result_entry(doc_id, "failed", error=str(e))
+        async def op(client: OutlineClient, doc_id: str) -> Dict[str, Any]:
+            if permanent:
+                success = await client.permanently_delete_document(doc_id)
+                if success:
+                    return _create_result_entry(
+                        doc_id, "success", title="Permanently deleted"
                     )
-                    failed += 1
-                except Exception as e:
-                    results.append(
-                        _create_result_entry(
-                            doc_id,
-                            "failed",
-                            error=f"Unexpected error: {str(e)}",
-                        )
-                    )
-                    failed += 1
+                return _create_result_entry(
+                    doc_id, "failed", error="Permanent deletion failed"
+                )
 
-            operation = "permanently delete" if permanent else "delete"
-            return _format_batch_results(
-                operation, len(document_ids), succeeded, failed, results
+            # Get document details before deleting
+            document = await client.get_document(doc_id)
+            doc_title = document.get("title", "Untitled")
+
+            # Move to trash
+            response = await client.post("documents.delete", {"id": doc_id})
+            if response.get("success", False):
+                return _create_result_entry(doc_id, "success", title=doc_title)
+            return _create_result_entry(
+                doc_id, "failed", error="Failed to move to trash"
             )
 
-        except OutlineClientError as e:
-            return f"Error initializing client: {str(e)}"
-        except Exception as e:
-            return f"Unexpected error: {str(e)}"
+        operation = "permanently delete" if permanent else "delete"
+        return await _run_batch(document_ids, operation, op)
 
     @mcp.tool(
         annotations=ToolAnnotations(
@@ -500,80 +424,41 @@ def register_tools(mcp) -> None:
         if not updates:
             return "Error: No updates provided."
 
-        results: List[Dict[str, Any]] = []
-        succeeded = 0
-        failed = 0
+        async def op(
+            client: OutlineClient, update_spec: BatchUpdateItem
+        ) -> Dict[str, Any]:
+            doc_id = update_spec.id
+            data: Dict[str, Any] = {"id": doc_id}
 
-        try:
-            client = await get_outline_client()
+            if update_spec.title is not None:
+                data["title"] = update_spec.title
 
-            for update_spec in updates:
-                doc_id = update_spec.id
+            if update_spec.text is not None:
+                data["text"] = update_spec.text
+                data["append"] = (
+                    update_spec.append
+                    if update_spec.append is not None
+                    else False
+                )
 
-                try:
-                    # Build update data
-                    data: Dict[str, Any] = {"id": doc_id}
+            response = await client.post("documents.update", data)
+            document = response.get("data", {})
 
-                    if update_spec.title is not None:
-                        data["title"] = update_spec.title
-
-                    if update_spec.text is not None:
-                        data["text"] = update_spec.text
-                        data["append"] = (
-                            update_spec.append
-                            if update_spec.append is not None
-                            else False
-                        )
-
-                    response = await client.post("documents.update", data)
-                    document = response.get("data", {})
-
-                    if document:
-                        cache = get_document_cache()
-                        await cache.invalidate_for_write(
-                            get_resolved_api_key(), doc_id
-                        )
-                        results.append(
-                            _create_result_entry(
-                                doc_id,
-                                "success",
-                                title=document.get("title", "Untitled"),
-                            )
-                        )
-                        succeeded += 1
-                    else:
-                        results.append(
-                            _create_result_entry(
-                                doc_id,
-                                "failed",
-                                error="Failed to update document",
-                            )
-                        )
-                        failed += 1
-
-                except OutlineClientError as e:
-                    results.append(
-                        _create_result_entry(doc_id, "failed", error=str(e))
-                    )
-                    failed += 1
-                except Exception as e:
-                    results.append(
-                        _create_result_entry(
-                            doc_id,
-                            "failed",
-                            error=f"Unexpected error: {str(e)}",
-                        )
-                    )
-                    failed += 1
-
-            return _format_batch_results(
-                "update", len(updates), succeeded, failed, results
+            if document:
+                cache = get_document_cache()
+                await cache.invalidate_for_write(
+                    get_resolved_api_key(), doc_id
+                )
+                return _create_result_entry(
+                    doc_id,
+                    "success",
+                    title=document.get("title", "Untitled"),
+                )
+            return _create_result_entry(
+                doc_id, "failed", error="Failed to update document"
             )
 
-        except OutlineClientError as e:
-            return f"Error initializing client: {str(e)}"
-        except Exception as e:
-            return f"Unexpected error: {str(e)}"
+        return await _run_batch(updates, "update", op, id_of=lambda u: u.id)
 
     @mcp.tool(
         annotations=ToolAnnotations(
@@ -619,83 +504,45 @@ def register_tools(mcp) -> None:
         if not documents:
             return "Error: No documents provided."
 
-        results: List[Dict[str, Any]] = []
-        succeeded = 0
-        failed = 0
         created_ids: List[str] = []
 
-        try:
-            client = await get_outline_client()
+        async def op(
+            client: OutlineClient, doc_spec: BatchCreateItem
+        ) -> Dict[str, Any]:
+            data: Dict[str, Any] = {
+                "title": doc_spec.title,
+                "collectionId": doc_spec.collection_id,
+                "text": doc_spec.text or "",
+                "publish": (
+                    doc_spec.publish if doc_spec.publish is not None else True
+                ),
+            }
+            if doc_spec.parent_document_id:
+                data["parentDocumentId"] = doc_spec.parent_document_id
 
-            for doc_spec in documents:
-                try:
-                    # Build create data
-                    data: Dict[str, Any] = {
-                        "title": doc_spec.title,
-                        "collectionId": doc_spec.collection_id,
-                        "text": doc_spec.text or "",
-                        "publish": (
-                            doc_spec.publish
-                            if doc_spec.publish is not None
-                            else True
-                        ),
-                    }
+            response = await client.post("documents.create", data)
+            document = response.get("data", {})
 
-                    if doc_spec.parent_document_id:
-                        data["parentDocumentId"] = doc_spec.parent_document_id
-
-                    response = await client.post("documents.create", data)
-                    document = response.get("data", {})
-
-                    if document:
-                        doc_id = document.get("id", "unknown")
-                        doc_title = document.get("title", "Untitled")
-                        created_ids.append(doc_id)
-                        results.append(
-                            _create_result_entry(
-                                doc_id, "success", title=doc_title
-                            )
-                        )
-                        succeeded += 1
-                    else:
-                        results.append(
-                            _create_result_entry(
-                                "unknown",
-                                "failed",
-                                error="Failed to create document",
-                            )
-                        )
-                        failed += 1
-
-                except OutlineClientError as e:
-                    results.append(
-                        _create_result_entry("unknown", "failed", error=str(e))
-                    )
-                    failed += 1
-                except Exception as e:
-                    results.append(
-                        _create_result_entry(
-                            "unknown",
-                            "failed",
-                            error=f"Unexpected error: {str(e)}",
-                        )
-                    )
-                    failed += 1
-
-            # Format results with created IDs
-            result_text = _format_batch_results(
-                "create", len(documents), succeeded, failed, results
+            if document:
+                doc_id = document.get("id", "unknown")
+                created_ids.append(doc_id)
+                return _create_result_entry(
+                    doc_id,
+                    "success",
+                    title=document.get("title", "Untitled"),
+                )
+            return _create_result_entry(
+                "unknown", "failed", error="Failed to create document"
             )
 
-            # Add created IDs section if any succeeded
-            if created_ids:
-                result_text += "\n\nCreated Document IDs:\n"
-                for doc_id in created_ids:
-                    result_text += f"  - {doc_id}\n"
+        result_text = await _run_batch(
+            documents, "create", op, id_of=lambda _: "unknown"
+        )
 
-            return result_text
+        # Add created IDs section if any succeeded
+        if created_ids:
+            result_text += "\n\nCreated Document IDs:\n"
+            for doc_id in created_ids:
+                result_text += f"  - {doc_id}\n"
 
-        except OutlineClientError as e:
-            return f"Error initializing client: {str(e)}"
-        except Exception as e:
-            return f"Unexpected error: {str(e)}"
+        return result_text

--- a/src/mcp_outline/utils/outline_client.py
+++ b/src/mcp_outline/utils/outline_client.py
@@ -8,7 +8,17 @@ pooling and rate limiting.
 import asyncio
 import os
 from datetime import datetime
-from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    TypeVar,
+)
 
 import httpx
 
@@ -45,6 +55,59 @@ def _sanitize_value(value: Optional[str]) -> Optional[str]:
         ):
             return sanitized[1:-1]
     return sanitized
+
+
+T = TypeVar("T")
+
+
+def _parse_json(response: httpx.Response) -> Dict[str, Any]:
+    """Parse a standard JSON API response.
+
+    Raises:
+        httpx.HTTPStatusError: For 4xx/5xx responses.
+    """
+    response.raise_for_status()
+    return response.json()
+
+
+def _parse_redirect_location(response: httpx.Response) -> str:
+    """Return the Location header from an attachment redirect.
+
+    Treats 3xx as the success case. Other statuses surface via
+    ``raise_for_status``.
+
+    Raises:
+        httpx.HTTPStatusError: For 4xx/5xx responses.
+        OutlineError: When the redirect lacks a Location header, or
+            the status is unexpected.
+    """
+    if response.status_code in (301, 302, 307, 308):
+        location = response.headers.get("Location")
+        if not location:
+            raise OutlineError(
+                "No Location header in attachment redirect response"
+            )
+        return location
+    response.raise_for_status()
+    raise OutlineError(
+        f"Unexpected status {response.status_code} from "
+        "attachments.redirect (expected 302)"
+    )
+
+
+def _parse_attachment_content(
+    response: httpx.Response,
+) -> Tuple[bytes, str]:
+    """Return ``(content, content_type)`` from an attachment fetch.
+
+    Raises:
+        httpx.HTTPStatusError: For 4xx/5xx responses.
+    """
+    response.raise_for_status()
+    content_type = response.headers.get(
+        "content-type", "application/octet-stream"
+    )
+    return response.content, content_type
 
 
 class OutlineClient:
@@ -199,21 +262,34 @@ class OutlineClient:
             except (TypeError, ValueError):
                 self._rate_limit_reset = None
 
-    async def post(
-        self, endpoint: str, data: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, Any]:
+    async def _request(
+        self,
+        endpoint: str,
+        *,
+        json: Optional[Dict[str, Any]] = None,
+        follow_redirects: bool = True,
+        parse: Callable[[httpx.Response], T],
+    ) -> T:
         """
-        Make an async POST request to the Outline API.
+        Make an async POST request with rate limiting and retry.
 
-        Implements proactive rate limiting by checking stored rate limit
-        headers before making requests, with automatic retry on 429.
+        Owns proactive rate-limit waiting, automatic retry on 429 with
+        backoff, and unified terminal error mapping. The ``parse``
+        callable decides what counts as success and reads the response
+        body, so callers differ only in request shape and parsing.
 
         Args:
             endpoint: The API endpoint to call.
-            data: The request payload.
+            json: The request payload (omitted from the body when None).
+            follow_redirects: Whether httpx follows 3xx responses. The
+                attachment-redirect caller sets this False to read the
+                Location header itself.
+            parse: Maps a successful response to the return value. May
+                call ``raise_for_status()`` to surface HTTP errors into
+                the retry and error-mapping machinery below.
 
         Returns:
-            The parsed JSON response.
+            Whatever ``parse`` returns.
 
         Raises:
             OutlineError: If the request fails.
@@ -240,15 +316,18 @@ class OutlineClient:
         while attempt < max_retries:
             try:
                 response = await self._client_pool.post(
-                    url, headers=headers, json=data
+                    url,
+                    headers=headers,
+                    json=json,
+                    follow_redirects=follow_redirects,
                 )
 
                 # Update rate limit state from response headers
                 self._update_rate_limits(response)
 
-                # Raise exception for 4XX/5XX responses
-                response.raise_for_status()
-                return response.json()
+                # parse() determines success and reads the body; a 429
+                # (or other 4xx/5xx) surfaces as HTTPStatusError below.
+                return parse(response)
 
             except httpx.HTTPStatusError as e:
                 last_exception = e
@@ -312,6 +391,27 @@ class OutlineClient:
             ) from last_exception
 
         raise OutlineError("API request failed after retries")
+
+    async def post(
+        self, endpoint: str, data: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """
+        Make an async POST request to the Outline API.
+
+        Implements proactive rate limiting by checking stored rate limit
+        headers before making requests, with automatic retry on 429.
+
+        Args:
+            endpoint: The API endpoint to call.
+            data: The request payload.
+
+        Returns:
+            The parsed JSON response.
+
+        Raises:
+            OutlineError: If the request fails.
+        """
+        return await self._request(endpoint, json=data, parse=_parse_json)
 
     async def list_api_keys(
         self,
@@ -708,92 +808,12 @@ class OutlineClient:
         Raises:
             OutlineError: If the request fails or no Location header.
         """
-        async with self._rate_limit_lock:
-            await self._wait_if_rate_limited()
-
-        url = f"{self.api_url}/attachments.redirect"
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "Content-Type": "application/json",
-        }
-
-        if self._client_pool is None:
-            raise OutlineError("Client pool not initialized")
-
-        max_retries = 3
-        attempt = 0
-        last_exception: Optional[Exception] = None
-
-        while attempt < max_retries:
-            try:
-                response = await self._client_pool.post(
-                    url,
-                    headers=headers,
-                    json={"id": attachment_id},
-                    follow_redirects=False,
-                )
-                self._update_rate_limits(response)
-
-                # 302 (and 301, 307, 308) is the normal success case: Outline
-                # returns the signed download URL in the Location header
-                if response.status_code in (301, 302, 307, 308):
-                    location = response.headers.get("Location")
-                    if not location:
-                        raise OutlineError(
-                            "No Location header in attachment redirect "
-                            "response"
-                        )
-                    return location
-
-                response.raise_for_status()
-                raise OutlineError(
-                    f"Unexpected status {response.status_code} from "
-                    "attachments.redirect (expected 302)"
-                )
-            except httpx.HTTPStatusError as e:
-                last_exception = e
-                status = getattr(e.response, "status_code", None)
-                if status == 429:
-                    retry_after = e.response.headers.get("Retry-After")
-                    if retry_after:
-                        try:
-                            sleep_seconds = float(retry_after)
-                        except (TypeError, ValueError):
-                            sleep_seconds = 1.0 * (2**attempt)
-                    else:
-                        sleep_seconds = 1.0 * (2**attempt)
-                    sleep_seconds = min(sleep_seconds, 60.0)
-                    if attempt + 1 >= max_retries:
-                        break
-                    await asyncio.sleep(sleep_seconds)
-                    attempt += 1
-                    continue
-                break
-            except (httpx.TimeoutException, httpx.RequestError) as e:
-                last_exception = e
-                break
-            except OutlineError:
-                raise
-
-        if (
-            isinstance(last_exception, httpx.HTTPStatusError)
-            and getattr(last_exception, "response", None) is not None
-        ):
-            status = last_exception.response.status_code
-            text = last_exception.response.text
-            raise OutlineError(
-                f"HTTP {status}: {text}",
-                status_code=status,
-            ) from last_exception
-        if isinstance(last_exception, httpx.TimeoutException):
-            raise OutlineError(
-                f"Request timeout: {str(last_exception)}"
-            ) from last_exception
-        if isinstance(last_exception, httpx.RequestError):
-            raise OutlineError(
-                f"API request failed: {str(last_exception)}"
-            ) from last_exception
-        raise OutlineError("API request failed after retries")
+        return await self._request(
+            "attachments.redirect",
+            json={"id": attachment_id},
+            follow_redirects=False,
+            parse=_parse_redirect_location,
+        )
 
     async def fetch_attachment_content(
         self, attachment_id: str
@@ -813,76 +833,9 @@ class OutlineClient:
         Raises:
             OutlineError: If the request fails.
         """
-        async with self._rate_limit_lock:
-            await self._wait_if_rate_limited()
-
-        url = f"{self.api_url}/attachments.redirect"
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "Content-Type": "application/json",
-        }
-
-        if self._client_pool is None:
-            raise OutlineError("Client pool not initialized")
-
-        max_retries = 3
-        attempt = 0
-        last_exception: Optional[Exception] = None
-
-        while attempt < max_retries:
-            try:
-                response = await self._client_pool.post(
-                    url,
-                    headers=headers,
-                    json={"id": attachment_id},
-                    follow_redirects=True,
-                )
-                self._update_rate_limits(response)
-                response.raise_for_status()
-
-                content_type = response.headers.get(
-                    "content-type", "application/octet-stream"
-                )
-                return response.content, content_type
-            except httpx.HTTPStatusError as e:
-                last_exception = e
-                status = getattr(e.response, "status_code", None)
-                if status == 429:
-                    retry_after = e.response.headers.get("Retry-After")
-                    if retry_after:
-                        try:
-                            sleep_seconds = float(retry_after)
-                        except (TypeError, ValueError):
-                            sleep_seconds = 1.0 * (2**attempt)
-                    else:
-                        sleep_seconds = 1.0 * (2**attempt)
-                    sleep_seconds = min(sleep_seconds, 60.0)
-                    if attempt + 1 >= max_retries:
-                        break
-                    await asyncio.sleep(sleep_seconds)
-                    attempt += 1
-                    continue
-                break
-            except (httpx.TimeoutException, httpx.RequestError) as e:
-                last_exception = e
-                break
-
-        if (
-            isinstance(last_exception, httpx.HTTPStatusError)
-            and getattr(last_exception, "response", None) is not None
-        ):
-            status = last_exception.response.status_code
-            text = last_exception.response.text
-            raise OutlineError(
-                f"HTTP {status}: {text}",
-                status_code=status,
-            ) from last_exception
-        if isinstance(last_exception, httpx.TimeoutException):
-            raise OutlineError(
-                f"Request timeout: {str(last_exception)}"
-            ) from last_exception
-        if isinstance(last_exception, httpx.RequestError):
-            raise OutlineError(
-                f"API request failed: {str(last_exception)}"
-            ) from last_exception
-        raise OutlineError("API request failed after retries")
+        return await self._request(
+            "attachments.redirect",
+            json={"id": attachment_id},
+            follow_redirects=True,
+            parse=_parse_attachment_content,
+        )

--- a/tests/features/documents/test_batch_operations.py
+++ b/tests/features/documents/test_batch_operations.py
@@ -716,6 +716,66 @@ class TestBatchCreateDocuments:
     @patch(
         "mcp_outline.features.documents.batch_operations.get_outline_client"
     )
+    async def test_batch_create_lists_created_ids_section(
+        self, mock_get_client, register_batch_tools
+    ):
+        """Created IDs appear in a dedicated 'Created Document IDs'
+        section, not only inline in the per-item details."""
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = [
+            {"data": {"id": "new1", "title": "Document 1"}},
+            {"data": {"id": "new2", "title": "Document 2"}},
+        ]
+        mock_get_client.return_value = mock_client
+
+        from mcp_outline.features.documents.models import (
+            BatchCreateItem,
+        )
+
+        documents = [
+            BatchCreateItem(title="Doc 1", collection_id="col1"),
+            BatchCreateItem(title="Doc 2", collection_id="col1"),
+        ]
+
+        result = await register_batch_tools.tools["batch_create_documents"](
+            documents
+        )
+
+        assert "Created Document IDs:" in result
+        assert "  - new1" in result
+        assert "  - new2" in result
+
+    @pytest.mark.asyncio
+    @patch(
+        "mcp_outline.features.documents.batch_operations.get_outline_client"
+    )
+    async def test_batch_create_omits_ids_section_when_all_fail(
+        self, mock_get_client, register_batch_tools
+    ):
+        """No 'Created Document IDs' section when nothing was created."""
+        mock_client = AsyncMock()
+        mock_client.post.return_value = {}  # no "data" -> failure
+        mock_get_client.return_value = mock_client
+
+        from mcp_outline.features.documents.models import (
+            BatchCreateItem,
+        )
+
+        documents = [
+            BatchCreateItem(title="Doc 1", collection_id="col1"),
+        ]
+
+        result = await register_batch_tools.tools["batch_create_documents"](
+            documents
+        )
+
+        assert "Failed: 1" in result
+        assert "Created Document IDs:" not in result
+
+    @pytest.mark.asyncio
+    @patch(
+        "mcp_outline.features.documents.batch_operations.get_outline_client"
+    )
     async def test_batch_create_empty_list(
         self, mock_get_client, register_batch_tools
     ):
@@ -723,6 +783,72 @@ class TestBatchCreateDocuments:
         result = await register_batch_tools.tools["batch_create_documents"]([])
 
         assert "Error: No documents provided" in result
+
+
+class TestRunBatchEngine:
+    """Tests for shared _run_batch behavior, exercised via archive.
+
+    These error paths are centralized in _run_batch, so covering them
+    once through one tool exercises them for all five batch tools.
+    """
+
+    @pytest.mark.asyncio
+    @patch(
+        "mcp_outline.features.documents.batch_operations.get_outline_client"
+    )
+    async def test_unexpected_exception_is_isolated(
+        self, mock_get_client, register_batch_tools
+    ):
+        """A non-OutlineClientError is isolated per item and the batch
+        continues with the remaining items."""
+        mock_client = AsyncMock()
+        mock_client.archive_document.side_effect = [
+            ValueError("boom"),
+            {"id": "doc2", "title": "Document 2"},
+        ]
+        mock_get_client.return_value = mock_client
+
+        result = await register_batch_tools.tools["batch_archive_documents"](
+            ["doc1", "doc2"]
+        )
+
+        assert "Total: 2" in result
+        assert "Succeeded: 1" in result
+        assert "Failed: 1" in result
+        assert "Unexpected error: boom" in result
+
+    @pytest.mark.asyncio
+    @patch(
+        "mcp_outline.features.documents.batch_operations.get_outline_client"
+    )
+    async def test_client_init_failure_reported(
+        self, mock_get_client, register_batch_tools
+    ):
+        """A client-init OutlineClientError aborts before the loop."""
+        mock_get_client.side_effect = OutlineClientError("no api key")
+
+        result = await register_batch_tools.tools["batch_archive_documents"](
+            ["doc1", "doc2"]
+        )
+
+        assert "Error initializing client: no api key" in result
+
+    @pytest.mark.asyncio
+    @patch(
+        "mcp_outline.features.documents.batch_operations.get_outline_client"
+    )
+    async def test_client_init_unexpected_error_reported(
+        self, mock_get_client, register_batch_tools
+    ):
+        """A non-OutlineClientError during init maps to the generic
+        unexpected-error message."""
+        mock_get_client.side_effect = RuntimeError("kaboom")
+
+        result = await register_batch_tools.tools["batch_archive_documents"](
+            ["doc1"]
+        )
+
+        assert "Unexpected error: kaboom" in result
 
 
 class TestHelperFunctions:

--- a/tests/utils/test_outline_client.py
+++ b/tests/utils/test_outline_client.py
@@ -133,6 +133,7 @@ class TestOutlineClient:
                     "Accept": "application/json",
                 },
                 json=data,
+                follow_redirects=True,
             )
 
             assert result == {"data": {"test": "value"}}
@@ -703,6 +704,44 @@ class TestOutlineClient:
             )
 
             assert content_type == "application/octet-stream"
+
+    @pytest.mark.asyncio
+    async def test_fetch_attachment_content_retries_on_429(self):
+        """Attachment fetch shares the request core's retry: 429 then 200.
+
+        Guards the consolidation onto ``_request`` — the attachment
+        adapters now inherit retry-on-429 from the shared core rather
+        than carrying their own copy.
+        """
+        client = OutlineClient()
+
+        mock_429 = MagicMock()
+        mock_429.status_code = 429
+        mock_429.headers = {"Retry-After": "0.01"}
+        mock_429.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Too Many Requests",
+            request=MagicMock(),
+            response=mock_429,
+        )
+
+        mock_success = MagicMock()
+        mock_success.status_code = 200
+        mock_success.headers = {"content-type": "application/pdf"}
+        mock_success.content = b"%PDF-1.4 binary content"
+        mock_success.raise_for_status = MagicMock()
+
+        with patch.object(
+            client._client_pool,
+            "post",
+            new=AsyncMock(side_effect=[mock_429, mock_success]),
+        ) as mock_post:
+            content, content_type = await client.fetch_attachment_content(
+                "6fe06f93-e331-408d-b954-6bb4ed50e67d"
+            )
+
+            assert mock_post.call_count == 2
+            assert content == b"%PDF-1.4 binary content"
+            assert content_type == "application/pdf"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Two internal, behavior-preserving refactors that collapse duplicated control-flow into single deep cores. **No public surface changes** — no new modules, tool interfaces, config flags, or dependencies. The MCP tool surface, `OutlineClient`'s public API, the resource scheme, and the registration flow are all unchanged.

### C1 — `OutlineClient` request plumbing → one `_request` core
The rate-limit/retry/error-mapping policy (~80 lines) was copied verbatim across `post`, `get_attachment_redirect_url`, and `fetch_attachment_content` — and had already started to drift (the redirect method carried an extra `except OutlineError: raise`; the attachment methods omitted the `Accept` header). A single private `_request(endpoint, *, json, follow_redirects, parse)` now owns rate-limit waiting, retry-on-429 with backoff, and terminal error mapping; the three callers become thin adapters differing only in `follow_redirects` and a `parse` callable (`_parse_json` / `_parse_redirect_location` / `_parse_attachment_content`). A retry-policy change now happens in one place instead of three.

### C3 — `batch_operations` skeleton → one `_run_batch` engine
The five batch tools each reimplemented an identical ~45-line skeleton (acquire client → iterate → isolate per-item errors → tally → format). A module-level `_run_batch(items, operation_label, op, *, id_of)` now owns all of it; each tool declares only its per-item async `op`. Cross-tool consistency is now guaranteed rather than maintained by discipline. Tool-specific bits stay in their tools: empty-input guards, `move`'s destination guard, `delete`'s operation label, and `create`'s "Created Document IDs" section. This extends the module's existing pattern of shared batch helpers (`_create_result_entry`, `_format_batch_results`).

## Reviewer note (honest tradeoff)

C1 is a clear win — it removes drift-prone triplicated control-flow for one hop of indirection.

C3 is the weaker of the two: it trades flat, independently-readable tool functions for an engine + per-item closure pattern (slightly more to hold in your head, mild tension with KISS), and `batch_create`'s `id_of=lambda _: "unknown"` + closure-captured `created_ids` is the one spot where the seam strains against a tool that doesn't fit cleanly. It's still a net positive (guaranteed consistency, −153 lines, consistent with existing helpers), but it's a reasonable place to push back if you prefer the flat version. The commits are independent — C1 (`69c0b9b`) can be taken without C3 if desired.

## Net line change

- `outline_client.py`: 888 → 841 (−47)
- `batch_operations.py`: 701 → 548 (−153)

The reduction is smaller than raw duplicated-line counts suggest — the new shared cores + per-call wrapper boilerplate offset some savings. The real win is locality, not line count.

## Tests

- New: `_run_batch` error-isolation + both client-init failure paths (previously untested, now covered once for all five tools); `batch_create` IDs-section present/absent; `fetch_attachment_content` retry-on-429 (proves attachments now inherit the shared retry).
- `test_post_request` gained `follow_redirects=True` in its `assert_called_once_with` (now passed explicitly; real behavior identical — the pool default was already `True`).

## Verification

- `ruff format --check` ✓ · `ruff check` ✓ · `pyright src/` → 0 errors
- Unit: **546 passed** · Integration: **16 passed**
- Reviewed for correctness across multiple angles + a gap sweep: no findings.
