### PR TITLE
build(deps): pin mcp[cli] to <2 ahead of breaking SDK v2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "mcp-outline",
       "source": "./",
       "description": "Connect Claude Code to Outline for document search, reading, creation, and management",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "author": {
         "name": "Vortiago"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-outline",
   "description": "Connect Claude Code to Outline for document search, reading, creation, and management",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "author": {
     "name": "Vortiago"
   },

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "mcp-outline": {
       "command": "uvx",
-      "args": ["mcp-outline==1.10.0"],
+      "args": ["mcp-outline==1.10.1"],
       "env": {
         "OUTLINE_API_KEY": "${OUTLINE_API_KEY:-}",
         "OUTLINE_API_URL": "${OUTLINE_API_URL:-}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.10"
 readme = "README.md"
 license-files = ["LICENSE"]
 dependencies = [
-    "mcp[cli]>=1.20.0",
+    "mcp[cli]>=1.20.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
 ]
@@ -28,7 +28,7 @@ mcp-outline = "mcp_outline.server:main"
 [dependency-groups]
 dev = [
     "poethepoet>=0.32.0",
-    "mcp[cli]>=1.20.0",
+    "mcp[cli]>=1.20.0,<2",
     "pytest>=8.4.0",
     "pytest-asyncio>=1.2.0",
     "pytest-cov>=6.0.0",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Vortiago/mcp-outline",
   "title": "Outline MCP Server",
   "description": "Connect AI assistants to Outline for document search, reading, and management",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "websiteUrl": "https://github.com/Vortiago/mcp-outline",
   "repository": {
     "url": "https://github.com/Vortiago/mcp-outline",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "mcp-outline",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/tests/test_dependency_pins.py
+++ b/tests/test_dependency_pins.py
@@ -1,0 +1,43 @@
+"""
+Guardrail tests for critical dependency version pins in pyproject.toml.
+
+Issue #134: the MCP Python SDK v2 is a breaking release (stateless
+protocol core -- no ``initialize`` handshake, no ``Mcp-Session-Id``
+header). The ``mcp[cli]`` requirement must keep an upper bound that
+excludes v2 so a routine re-lock cannot silently pull it in.
+"""
+
+import re
+from pathlib import Path
+
+from packaging.specifiers import SpecifierSet
+
+_PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+_MCP_REQ = re.compile(r'"mcp\[cli\]([^"]*)"')
+
+
+def _mcp_specifiers() -> list[str]:
+    """Return the version specifier of every ``mcp[cli]`` requirement
+    declared in pyproject.toml (runtime deps + dev group)."""
+    text = _PYPROJECT.read_text(encoding="utf-8")
+    return _MCP_REQ.findall(text)
+
+
+def test_pyproject_declares_two_mcp_requirements():
+    """Both the runtime deps and the dev group pin ``mcp[cli]``."""
+    assert len(_mcp_specifiers()) == 2
+
+
+def test_mcp_cli_pinned_below_v2():
+    """Every ``mcp[cli]`` pin excludes the breaking SDK v2 while still
+    allowing the latest v1 release (issue #134)."""
+    specs = _mcp_specifiers()
+    assert specs, "no mcp[cli] requirement found in pyproject.toml"
+    for spec in specs:
+        sset = SpecifierSet(spec)
+        assert not sset.contains("2.0.0", prereleases=True), (
+            f"mcp[cli]{spec} allows the breaking SDK v2"
+        )
+        assert sset.contains("1.28.1"), (
+            f"mcp[cli]{spec} must still allow the latest v1 release"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -550,14 +550,14 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.20.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.20.0,<2" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "anyio", specifier = ">=4.11.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.20.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.20.0,<2" },
     { name = "poethepoet", specifier = ">=0.32.0" },
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pyright", specifier = ">=1.1.407" },


### PR DESCRIPTION
## Summary

Closes #134.

`pyproject.toml` pinned `mcp[cli]>=1.20.0` with **no upper bound** in both the runtime deps and the dev group. The MCP Python SDK v2 is a **breaking** release (stateless protocol core — no `initialize` handshake, no `Mcp-Session-Id` header), and v2 pre-releases (`2.0.0a1`–`2.0.0b1`) are **already on PyPI**. Once v2 stable lands, a routine `uv lock` / install could silently pull it in and break the server.

## Changes

- Add `,<2` to both `mcp[cli]` requirements (`pyproject.toml` lines 16 + 31).
- Re-lock: `mcp` stays resolved at `1.26.0` (no functional dependency change).
- Add `tests/test_dependency_pins.py` — a guardrail that fails if either `mcp[cli]` pin ever stops excluding v2 (uses `packaging.SpecifierSet`; pure-text parse, no `tomllib`, so it runs across the 3.10–3.13 CI matrix).

## Verification

- Guardrail test: RED before the pin, GREEN after.
- `uv run poe test-unit` → 548 passed · `uv run poe test-integration` → 16 passed.
- `ruff format --check`, `ruff check`, `pyright src/` all clean.

## Out of scope

The actual v2 / stateless migration (tracked separately per #134). No version bump / release.

## Release

Bumps version **1.10.0 → 1.10.1** (patch) across `server.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `.mcp.json` so a new version can be tagged/published right after merge. No `feat`/breaking changes since v1.10.0 → patch.
